### PR TITLE
fix nginx proxy crash when ingress is disabled

### DIFF
--- a/charts/inventree/templates/nginx-configmap.yaml
+++ b/charts/inventree/templates/nginx-configmap.yaml
@@ -17,7 +17,7 @@ data:
         listen 80 deferred;
         client_max_body_size 4G;
     
-        server_name {{ (include "ingress.listServers" (dict "data" . )) }};
+        server_name {{ include "ingress.listServers" (dict "data" .) | default (trimPrefix "https://" (trimPrefix "http://" .Values.global.siteUrl)) }};
     
         keepalive_timeout 5;
     


### PR DESCRIPTION
Fix nginx proxy crash when ingress is disabled by falling back to `global.siteUrl` for `server_name`.

closes https://github.com/inventree/helm-charts/issues/42