### PR TITLE
Additional values for init and worker containers

### DIFF
--- a/charts/inventree/templates/deployment.yaml
+++ b/charts/inventree/templates/deployment.yaml
@@ -33,14 +33,21 @@ spec:
             - >
               invoke migrate &&
               invoke static
-          {{- if .Values.persistence.enabled }}
           volumeMounts:
+            {{- if .Values.persistence.enabled }}
             - name: inventree-data
               mountPath: {{ .Values.persistence.mountPath }}
+            {{- end }}
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
             - name: INVENTREE_SITE_URL
               value: {{ .Values.global.siteUrl }}
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}    
           {{- (include "inventree.renderSecrets" (dict "data" .Values.global.dbSecrets)) | nindent 10 -}}
       {{- end -}}
       {{- with .Values.imagePullSecrets }}

--- a/charts/inventree/templates/worker-deployment.yaml
+++ b/charts/inventree/templates/worker-deployment.yaml
@@ -48,6 +48,10 @@ spec:
           env:
             - name: INVENTREE_SITE_URL
               value: {{ .Values.global.siteUrl }}
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }} 
             {{- if not (empty .Values.global.cacheSecrets) }}
             - name: INVENTREE_CACHE_ENABLED
               value: "True"
@@ -71,15 +75,19 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if .Values.persistence.enabled }}
             - name: inventree-data
-              mountPath: /home/inventree/data
+              mountPath: {{ .Values.persistence.mountPath }}
+            {{- end }}
           {{- with .Values.worker.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
+        {{- if .Values.persistence.enabled }}
         - name: inventree-data
           persistentVolumeClaim:
-            claimName: inventree-data
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{ else }}inventree-data{{ end }}
+        {{- end }}
       {{- with .Values.worker.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
I was trying to use S3 for storage and found that I needed to pass some environment variables to the init and worker containers. I also needed to disable persistence and provide an emptyDir in place of the persistent storage. I have tested these changes on my Kubernetes cluster.

Change summary
- provide env variables and volume mounts to the  initContainer.
- provide env variables to volume mounts to the worker container and allow persistence to be disabled like the other containers.