### PR TITLE
fix: enable plugins in worker deployment

### DIFF
--- a/charts/inventree/Chart.yaml
+++ b/charts/inventree/Chart.yaml
@@ -12,7 +12,7 @@ icon: https://raw.githubusercontent.com/inventree/InvenTree/refs/heads/master/as
 type: application
 
 # Version info - CHANGEME
-version: 0.4.21
+version: 0.4.22
 appVersion: "1.4.2"
 
 # Artifacthub annotations

--- a/charts/inventree/templates/worker-deployment.yaml
+++ b/charts/inventree/templates/worker-deployment.yaml
@@ -56,6 +56,10 @@ spec:
             - name: INVENTREE_CACHE_ENABLED
               value: "True"
             {{- end -}}
+            {{- if .Values.plugins.enabled }}
+            - name: INVENTREE_PLUGINS_ENABLED
+              value: "True"
+            {{- end }}
           {{- (include "inventree.renderSecrets" (dict "data" .Values.global.cacheSecrets)) | nindent 10 -}}
           {{- (include "inventree.renderSecrets" (dict "data" .Values.global.dbSecrets)) | nindent 10 }}
           {{- (include "inventree.renderSecrets" (dict "data" .Values.global.emailSecrets)) | nindent 10 -}}


### PR DESCRIPTION
Hi, I had the problem, that `INVENTREE_PLUGINS_ENABLED` was not set in the worker when the value `plugins.enabled` was set to `true` in the values and so external plugins are not loaded in the worker.
This PR fixes this by adding the same block from `deployment.yaml` to `worker-deployment.yaml`. I also took it upon me to bump the chart version, hope thats okay :)

I think a shared common-env template for both deployments would prevent similar bugs from happening in the future but I didn't implement this in this PR to keep it minimal.

Thanks!