### PR TITLE
refactor: common env variables template

### DIFF
--- a/charts/inventree/Chart.yaml
+++ b/charts/inventree/Chart.yaml
@@ -12,8 +12,8 @@ icon: https://raw.githubusercontent.com/inventree/InvenTree/refs/heads/master/as
 type: application
 
 # Version info - CHANGEME
-version: 0.4.23
-appVersion: "1.4.3"
+version: 0.5.0
+appVersion: "1.4.4"
 
 # Artifacthub annotations
 artifacthub.io/license: MIT

--- a/charts/inventree/templates/_helpers.tpl
+++ b/charts/inventree/templates/_helpers.tpl
@@ -86,14 +86,14 @@ Render secrets
 */}}
 {{- define "inventree.renderSecrets" -}}
   {{- range .data }}
-  - name: {{ .name }}
+- name: {{ .name }}
   {{- if .value }}
-    value: {{ .value | quote }}
+  value: {{ .value | quote }}
   {{- else if .valueFrom }}
-    valueFrom:
-      secretKeyRef:
-        name: {{ .valueFrom.secretKeyRef.name }}
-        key: {{ .valueFrom.secretKeyRef.key }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .valueFrom.secretKeyRef.name }}
+      key: {{ .valueFrom.secretKeyRef.key }}
   {{- else -}}
     {{- fail "Unhandled value, expecting either value for valueFrom" -}}
   {{- end -}}
@@ -158,3 +158,26 @@ Convert values to an object
 
   {{- $objectValues | toYaml -}}
 {{- end -}}
+
+{{/*
+Common environment variables for all InvenTree containers
+*/}}
+{{- define "inventree.env.common" -}}
+- name: INVENTREE_SITE_URL
+  value: {{ .Values.global.siteUrl }}
+{{- range $key, $value := .Values.env }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- if .Values.plugins.enabled }}
+- name: INVENTREE_PLUGINS_ENABLED
+  value: "True"
+{{- end }}
+{{- (include "inventree.renderSecrets" (dict "data" .Values.global.dbSecrets)) }}
+{{- (include "inventree.renderSecrets" (dict "data" .Values.global.cacheSecrets)) }}
+{{- if not (empty .Values.global.cacheSecrets) }}
+- name: INVENTREE_CACHE_ENABLED
+  value: "True"
+{{- end -}}
+{{- (include "inventree.renderSecrets" (dict "data" .Values.global.emailSecrets)) }}
+{{- end }}

--- a/charts/inventree/templates/deployment.yaml
+++ b/charts/inventree/templates/deployment.yaml
@@ -47,8 +47,8 @@ spec:
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
-            {{- end }}    
-          {{- (include "inventree.renderSecrets" (dict "data" .Values.global.dbSecrets)) | nindent 10 -}}
+            {{- end -}}
+            {{- (include "inventree.renderSecrets" (dict "data" .Values.global.dbSecrets)) | nindent 12 -}}
       {{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -72,18 +72,12 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           env:
-            - name: INVENTREE_SITE_URL
-              value: {{ .Values.global.siteUrl }}
-           {{- range $key, $value := .Values.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-           {{- end }}              
+            {{- include "inventree.env.common" . | nindent 12 -}}
+            {{- /*
+            Backend-specific environment variables 
+            */}}
             - name: INVENTREE_TRUSTED_ORIGINS
-              value: {{ (include "ingress.listHosts" (dict "data" . )) -}}
-            {{- if not (empty .Values.global.cacheSecrets) }}
-            - name: INVENTREE_CACHE_ENABLED
-              value: "True"
-            {{- end -}}
+              value: {{ (include "ingress.listHosts" (dict "data" . )) }}
             {{- with .Values.global.ssoConfig }}
             {{- if .backends }}
             - name: INVENTREE_SOCIAL_BACKENDS
@@ -97,13 +91,6 @@ spec:
                   key: providers
             {{- end -}}
             {{- end -}}
-            {{- if .Values.plugins.enabled }}
-            - name: INVENTREE_PLUGINS_ENABLED
-              value: "True"
-            {{- end }}
-          {{- (include "inventree.renderSecrets" (dict "data" .Values.global.cacheSecrets)) | nindent 10 -}}
-          {{- (include "inventree.renderSecrets" (dict "data" .Values.global.dbSecrets)) | nindent 10 -}}
-          {{- (include "inventree.renderSecrets" (dict "data" .Values.global.emailSecrets)) | nindent 10 -}}
           {{- if .Values.global.adminSecret }}
           envFrom:
             - secretRef:

--- a/charts/inventree/templates/worker-deployment.yaml
+++ b/charts/inventree/templates/worker-deployment.yaml
@@ -46,23 +46,7 @@ spec:
           #    containerPort: {{ .Values.worker.service.port }}
           #    protocol: TCP
           env:
-            - name: INVENTREE_SITE_URL
-              value: {{ .Values.global.siteUrl }}
-            {{- range $key, $value := .Values.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }} 
-            {{- if not (empty .Values.global.cacheSecrets) }}
-            - name: INVENTREE_CACHE_ENABLED
-              value: "True"
-            {{- end -}}
-            {{- if .Values.plugins.enabled }}
-            - name: INVENTREE_PLUGINS_ENABLED
-              value: "True"
-            {{- end }}
-          {{- (include "inventree.renderSecrets" (dict "data" .Values.global.cacheSecrets)) | nindent 10 -}}
-          {{- (include "inventree.renderSecrets" (dict "data" .Values.global.dbSecrets)) | nindent 10 }}
-          {{- (include "inventree.renderSecrets" (dict "data" .Values.global.emailSecrets)) | nindent 10 -}}
+            {{- include "inventree.env.common" . | nindent 12 -}}
           {{/*
           # TODO: Figure out a way to check status
           {{- with .Values.worker.livenessProbe }}


### PR DESCRIPTION
Hi, its been a while... but trying to keep promise from #53 😄

This is what I was thinking would be better. Keeping the common env variables in the shared `_helpers.tpl` template. This is more or less just a cosmetic change but could possibly prevent some bugs (like #53).

Using the same common env in the deployment's `initContainer` would deduplicate one more copy, but would expose more env variables to that container, so I wanted to check what you think about that first?

<details>
<summary>Diff of output before/after</summary>

The following diff was created using  `helm template name charts/inventree -f values.yaml` and the following demo `values.yaml` once on `main` and on this PR's branch and shows that the output just has some less empty lines and slightly different ordering.


```yaml
# values.yaml
global:
  adminSecret: "admin-secret-name"
  cacheSecrets:
    - name: INVENTREE_CACHE_HOST
      value: "cache-host"
    - name: INVENTREE_CACHE_PORT
      value: "1234"
    - name: INVENTREE_CACHE_PASSWORD
      value: "cache-password"
    - name: INVENTREE_CACHE_USER
      value: "cache-user"
  dbSecrets:
    - name: INVENTREE_DB_HOST
      value: "db-host"
    - name: INVENTREE_DB_PORT
      value: "1234"
    - name: INVENTREE_DB_NAME
      value: "db-name"
    - name: INVENTREE_DB_USER
      value: "db-user"
    - name: INVENTREE_DB_PASSWORD
      value: "db-password"
  emailSecrets:
    - name: INVENTREE_EMAIL_HOST
      value: "email-host"
    - name: INVENTREE_EMAIL_PORT
      value: "1234"
    - name: INVENTREE_EMAIL_USERNAME
      value: "email-user"
    - name: INVENTREE_EMAIL_PASSWORD
      value: "email-password"
  ssoConfig:
    backends:
      - allauth.socialaccount.providers.openid_connect
    providerSecretName: "sso-provider-secret"

env:
  INVENTREE_CUSTOM_ENV: "custom-value"
```

Diff

```diff
<           
---
>             
195,206c195
<               value: "custom-value"              
<             - name: INVENTREE_TRUSTED_ORIGINS
<               value: ""
<             - name: INVENTREE_CACHE_ENABLED
<               value: "True"
<             - name: INVENTREE_SOCIAL_BACKENDS
<               value: 'allauth.socialaccount.providers.openid_connect'
<             - name: INVENTREE_SOCIAL_PROVIDERS
<               valueFrom:
<                 secretKeyRef:
<                   name: sso-provider-secret
<                   key: providers
---
>               value: "custom-value"
209,218d197
<           
<             - name: INVENTREE_CACHE_HOST
<               value: "cache-host"
<             - name: INVENTREE_CACHE_PORT
<               value: "1234"
<             - name: INVENTREE_CACHE_PASSWORD
<               value: "cache-password"
<             - name: INVENTREE_CACHE_USER
<               value: "cache-user"
<           
229c208,217
<           
---
>             - name: INVENTREE_CACHE_HOST
>               value: "cache-host"
>             - name: INVENTREE_CACHE_PORT
>               value: "1234"
>             - name: INVENTREE_CACHE_PASSWORD
>               value: "cache-password"
>             - name: INVENTREE_CACHE_USER
>               value: "cache-user"
>             - name: INVENTREE_CACHE_ENABLED
>               value: "True"
237a226,234
>             - name: INVENTREE_TRUSTED_ORIGINS
>               value: ""
>             - name: INVENTREE_SOCIAL_BACKENDS
>               value: 'allauth.socialaccount.providers.openid_connect'
>             - name: INVENTREE_SOCIAL_PROVIDERS
>               valueFrom:
>                 secretKeyRef:
>                   name: sso-provider-secret
>                   key: providers
305,306d301
<             - name: INVENTREE_CACHE_ENABLED
<               value: "True"
309,318d303
<           
<             - name: INVENTREE_CACHE_HOST
<               value: "cache-host"
<             - name: INVENTREE_CACHE_PORT
<               value: "1234"
<             - name: INVENTREE_CACHE_PASSWORD
<               value: "cache-password"
<             - name: INVENTREE_CACHE_USER
<               value: "cache-user"
<           
329c314,323
<           
---
>             - name: INVENTREE_CACHE_HOST
>               value: "cache-host"
>             - name: INVENTREE_CACHE_PORT
>               value: "1234"
>             - name: INVENTREE_CACHE_PASSWORD
>               value: "cache-password"
>             - name: INVENTREE_CACHE_USER
>               value: "cache-user"
>             - name: INVENTREE_CACHE_ENABLED
>               value: "True"

```
</details>

Note: I did not check this on a live cluster, but due to the diff showing no changes but ordering I am positive it should all work fine. If required, I can manually test though